### PR TITLE
Update Netlify hostname to avoid CORS error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # ebook-test-manifests
 
-https://ebook-test-manifests.netlify.com/
+https://ebook-test-manifests.netlify.app/

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 <body>
     <script>
 
-        var manifest = "https://ebook-test-manifests.netlify.com/collection/index.json";
+        var manifest = "https://ebook-test-manifests.netlify.app/collection/index.json";
         var iiif, iiifExplorer;
 
         function updateIIIFLink(manifestUrl) {


### PR DESCRIPTION
I also hit UniversalViewer/uv-ebook-components#5 and I think it's because there are still some references to `netlify.com` that are causing CORS problems (the reference in `index.html` don't seem to show up in search, oddly).

I _think_ this PR should fix the issue.